### PR TITLE
#361, added AspectJ compilation to POM

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="target/classes" path="services"/>
+	<classpathentry including="**/*.java" kind="src" output="target/classes" path="services"/>
 	<classpathentry kind="src" output="target/classes" path="domain"/>
 	<classpathentry kind="src" output="target/classes" path="src"/>
 	<classpathentry kind="src" output="target/classes" path="aspects"/>
-	<classpathentry kind="src" output="target/test-classes" path="test"/>
+	<classpathentry including="**/*.java" kind="src" output="target/test-classes" path="test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
 	<classpathentry kind="con" path="org.maven.ide.eclipse.MAVEN2_CLASSPATH_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER"/>

--- a/.project
+++ b/.project
@@ -6,7 +6,7 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>org.eclipse.jdt.core.javabuilder</name>
+			<name>org.eclipse.ajdt.core.ajbuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
@@ -22,6 +22,7 @@
 		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.ajdt.ui.ajnature</nature>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.maven.ide.eclipse.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,32 @@
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-tx</artifactId>
+			<version>3.0.6.RELEASE</version>
+			<type>jar</type>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-orm</artifactId>
+			<version>3.0.6.RELEASE</version>
+			<type>jar</type>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.persistence</groupId>
+			<artifactId>persistence-api</artifactId>
+			<version>1.0</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.aspectj</groupId>
+			<artifactId>aspectjrt</artifactId>
+			<version>1.6.7</version>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<directory>${project.basedir}/target</directory>
@@ -159,15 +185,39 @@
 				</executions>
 			</plugin>
 			<plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
-                    <excludes>
-                    </excludes>
-                </configuration>
-             </plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
+				<configuration>
+					<source>1.5</source>
+					<target>1.5</target>
+					<excludes>
+					</excludes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>aspectj-maven-plugin</artifactId>
+				<version>1.3</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>compile</goal>
+							<goal>test-compile</goal>
+						</goals>
+						<configuration>
+							<verbose>false</verbose>
+							<complianceLevel>1.5</complianceLevel>
+							<weaveDependencies>
+								<weaveDependency>
+									<groupId>org.springframework</groupId>
+									<artifactId>spring-aspects</artifactId>
+								</weaveDependency>
+							</weaveDependencies>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
The StateLogging aspects now get compiled and woven. The AspectJ nature of the Eclipse project remains when updating the Eclipse project files based on the POM.

Spring AOP with AspectJ introduces some strange dependencies, most notable Spring TX and Spring ORM(!). This appears to be a known problem. At the same time, these dependencies lead to warnings during the weaving process as some of the aspects defined in those libraries never get woven in the common project.
