### PR TITLE
Add sonatype repository for snapshot distribution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,16 @@
   </parent>
 
 
+  <!-- Sonatype OSS repo for resolving snapshot dependencies -->
+
+  <repositories>
+    <repository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </repository>
+  </repositories>
+
+
   <dependencies>
 
     <!-- Power TAC -->


### PR DESCRIPTION
I intended this to be inherited from powertac-parent, but of course that doesn't work when it doesn't already have powertac-parent locally and we're not telling mvn where to find it.